### PR TITLE
Add ML Proto Files from Apache Spark

### DIFF
--- a/src/spark/connect/ml.proto
+++ b/src/spark/connect/ml.proto
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = 'proto3';
+
+package spark.connect;
+
+import "spark/connect/relations.proto";
+import "spark/connect/expressions.proto";
+import "spark/connect/ml_common.proto";
+
+option java_multiple_files = true;
+option java_package = "org.apache.spark.connect.proto";
+option go_package = "internal/generated";
+
+// Command for ML
+message MlCommand {
+  oneof command {
+    Fit fit = 1;
+    Fetch fetch = 2;
+    Delete delete = 3;
+    Write write = 4;
+    Read read = 5;
+    Evaluate evaluate = 6;
+    CleanCache clean_cache = 7;
+    GetCacheInfo get_cache_info = 8;
+  }
+
+  // Command for estimator.fit(dataset)
+  message Fit {
+    // (Required) Estimator information (its type should be OPERATOR_TYPE_ESTIMATOR)
+    MlOperator estimator = 1;
+    // (Optional) parameters of the Estimator
+    optional MlParams params = 2;
+    // (Required) the training dataset
+    Relation dataset = 3;
+  }
+
+  // Command to delete the cached objects which could be a model
+  // or summary evaluated by a model
+  message Delete {
+    repeated ObjectRef obj_refs = 1;
+  }
+
+  // Force to clean up all the ML cached objects
+  message CleanCache { }
+
+  // Get the information of all the ML cached objects
+  message GetCacheInfo { }
+
+  // Command to write ML operator
+  message Write {
+    // It could be an estimator/evaluator or the cached model
+    oneof type {
+      // Estimator or evaluator
+      MlOperator operator = 1;
+      // The cached model
+      ObjectRef obj_ref = 2;
+    }
+    // (Optional) The parameters of operator which could be estimator/evaluator or a cached model
+    optional MlParams params = 3;
+    // (Required) Save the ML instance to the path
+    string path = 4;
+    // (Optional) Overwrites if the output path already exists.
+    optional bool should_overwrite = 5;
+    // (Optional) The options of the writer
+    map<string, string> options = 6;
+  }
+
+  // Command to load ML operator.
+  message Read {
+    // (Required) ML operator information
+    MlOperator operator = 1;
+    // (Required) Load the ML instance from the input path
+    string path = 2;
+  }
+
+  // Command for evaluator.evaluate(dataset)
+  message Evaluate {
+    // (Required) Evaluator information (its type should be OPERATOR_TYPE_EVALUATOR)
+    MlOperator evaluator = 1;
+    // (Optional) parameters of the Evaluator
+    optional MlParams params = 2;
+    // (Required) the evaluating dataset
+    Relation dataset = 3;
+  }
+}
+
+// The result of MlCommand
+message MlCommandResult {
+  oneof result_type {
+    // The result of the attribute
+    Expression.Literal param = 1;
+    // Evaluate a Dataset in a model and return the cached ID of summary
+    string summary = 2;
+    // Operator information
+    MlOperatorInfo operator_info = 3;
+  }
+
+  // Represents an operator info
+  message MlOperatorInfo {
+    oneof type {
+      // The cached object which could be a model or summary evaluated by a model
+      ObjectRef obj_ref = 1;
+      // Operator name
+      string name = 2;
+    }
+    // (Optional) the 'uid' of a ML object
+    // Note it is different from the 'id' of a cached object.
+    optional string uid = 3;
+    // (Optional) parameters
+    optional MlParams params = 4;
+  }
+}

--- a/src/spark/connect/ml_common.proto
+++ b/src/spark/connect/ml_common.proto
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = 'proto3';
+
+package spark.connect;
+
+import "spark/connect/expressions.proto";
+
+option java_multiple_files = true;
+option java_package = "org.apache.spark.connect.proto";
+option go_package = "internal/generated";
+
+// MlParams stores param settings for ML Estimator / Transformer / Evaluator
+message MlParams {
+  // User-supplied params
+  map<string, Expression.Literal> params = 1;
+}
+
+// MLOperator represents the ML operators like (Estimator, Transformer or Evaluator)
+message MlOperator {
+  // (Required) The qualified name of the ML operator.
+  string name = 1;
+
+  // (Required) Unique id of the ML operator
+  string uid = 2;
+
+  // (Required) Represents what the ML operator is
+  OperatorType type = 3;
+
+  enum OperatorType {
+    OPERATOR_TYPE_UNSPECIFIED = 0;
+    // ML estimator
+    OPERATOR_TYPE_ESTIMATOR = 1;
+    // ML transformer (non-model)
+    OPERATOR_TYPE_TRANSFORMER = 2;
+    // ML evaluator
+    OPERATOR_TYPE_EVALUATOR = 3;
+    // ML model
+    OPERATOR_TYPE_MODEL = 4;
+  }
+}
+
+// Represents a reference to the cached object which could be a model
+// or summary evaluated by a model
+message ObjectRef {
+  // (Required) The ID is used to lookup the object on the server side.
+  // Note it is different from the 'uid' of a ML object.
+  string id = 1;
+}


### PR DESCRIPTION
### **Summary**

This PR introduces the Machine Learning (ML) protocol buffer definitions from the upstream Apache Spark repository. These proto files define the ML-related APIs used by Spark Connect for representing ML operators, parameters, cached model references, and client–server ML commands.

### **What’s Included**

This PR adds the following proto definitions:

* **`ml_common.proto`**

  * `MlParams` for storing parameter maps
  * `MlOperator` for representing Estimators, Transformers, Evaluators, and Models
  * `ObjectRef` for referencing cached ML objects on the server

* **`ml.proto` (or MlCommand proto)**

  * `MlCommand` definitions for:

    * `Fit` (training estimators)
    * `Evaluate` (evaluating evaluators)
    * `Write` / `Read` (saving & loading ML instances)
    * `Fetch`, `Delete`, `CleanCache`, `GetCacheInfo`
  * `MlCommandResult` for returning model references, parameters, or operator info

### **Purpose**

These files are required to support Spark Connect’s ML APIs, enabling clients to:

* Train ML models remotely
* Evaluate models
* Read/write ML operators
* Manage cached ML objects
* Pass parameters and operator metadata through the Connect protocol

This aligns our implementation with upstream Spark and lays the groundwork for full ML pipeline support via Spark Connect.

### **Source**

The proto files were copied directly from the **original Apache Spark repository**, ensuring compatibility with current Spark Connect ML functionality.

### **No Behavior Changes**

This PR only adds schema definitions and no runtime logic changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added machine learning command protocol enabling model training, evaluation, and prediction operations
  * Introduced model persistence with read/write capabilities and object caching
  * Added parameter management and support for multiple ML operator types (estimators, transformers, evaluators, models)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->