### PR TITLE
fix: dynamic column width calculation in DataFrame::show()

### DIFF
--- a/src/dataframe.cpp
+++ b/src/dataframe.cpp
@@ -204,11 +204,13 @@ void DataFrame::show(int max_rows)
 
     auto batch = batches[0];
     int num_columns = batch->num_columns();
-    int64_t num_rows = std::min(batch->num_rows(), static_cast<int64_t>(max_rows));
-
+    int64_t num_rows = batch->num_rows();
+    if (max_rows > 0)
+    {
+        num_rows = std::min(num_rows, static_cast<int64_t>(max_rows));
+    }
     std::vector<std::string> headers;
     std::vector<int> col_widths(num_columns);
-
     std::vector<std::vector<std::string>> string_data(num_rows, std::vector<std::string>(num_columns));
     
     for (int i = 0; i < num_columns; ++i)


### PR DESCRIPTION
Previously, column widths were hardcoded to 12 characters, causing
misalignment for long values or headers.

This change:

- Calculates column widths dynamically based on header and data length.
- Fixes std::chrono compilation issues on macOS.
- Adds proper padding and alignment for the output table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Precomputes cell text for all supported data types for faster, more consistent table rendering.
  * Better handling and formatting of nulls and values for numbers, booleans, strings, dates, timestamps, and decimals.
  * Dynamic column widths derived from headers and data with two-space padding to reduce truncation.
  * Unified bordered layout with consistent header, row, and footer separators for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->