### PR TITLE
SCCPP-fix-ml-proto-fetch-definition: Add missing Fetch message to ml.…

### DIFF
--- a/src/spark/connect/ml.proto
+++ b/src/spark/connect/ml.proto
@@ -50,6 +50,20 @@ message MlCommand {
     Relation dataset = 3;
   }
 
+  // Command to fetch attributes or parameters from ML operators
+  // This can be used to retrieve specific attributes from estimators, evaluators, or cached models
+  message Fetch {
+    // ML operator information - can be an estimator/evaluator or a cached model
+    oneof type {
+      // Estimator or evaluator
+      MlOperator operator = 1;
+      // The cached model
+      ObjectRef obj_ref = 2;
+    }
+    // (Required) The name of the attribute to fetch
+    string attribute = 3;
+  }
+
   // Command to delete the cached objects which could be a model
   // or summary evaluated by a model
   message Delete {


### PR DESCRIPTION
## **Summary**

This PR adds the missing `Fetch` message definition to `spark/connect/ml.proto`. The `Fetch` message was referenced inside the `MlCommand` `oneof` block but never defined, causing protobuf compilation to fail during `make proto`.

## **What’s Included**

This PR introduces the `Fetch` message following the design patterns used in the Apache Spark 3.5 ML Connect protocol:

### **Added definition:**

* **Fetch** message, supporting:

  * Retrieving attributes from ML operators
  * Fetching parameter values from cached model objects
  * Using a `oneof` source distinguishing between `MlOperator` and `ObjectRef`
  * Returning values through the existing `MlCommandResult` structure

### **Why this matters:**

* Prior to this fix, protobuf generation failed with:

  ```
  spark/connect/ml.proto:34:5: "Fetch" is not defined.
  ```

## **Purpose**

This update ensures that all commands defined in `MlCommand` have corresponding message implementations.
It restores successful protobuf generation and fully aligns the ML protocol schema with Spark Connect’s expected structure for attribute-fetch operations.

## **Source / Reference**

The `Fetch` message is modeled after the Apache Spark Connect ML protocol patterns for interacting with operators, parameters, and cached objects.

## **No Behavior Changes**

This PR adds only a missing schema definition.
There are **no runtime or behavioral changes**.

---

### **Closes: #4**