### PR TITLE
Add Column Expression support for DataFrame select

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_BUILD_TYPE Debug)
 
 
 #########################################################################

--- a/src/dataframe.cpp
+++ b/src/dataframe.cpp
@@ -25,7 +25,7 @@
 using namespace spark::connect;
 
 DataFrame::DataFrame(std::shared_ptr<spark::connect::SparkConnectService::Stub> stub,
-                     spark::connect::Plan plan,
+                     Plan plan,
                      std::string session_id,
                      std::string user_id)
     : stub_(stub),
@@ -446,7 +446,7 @@ void DataFrame::printSchema() const
 
 DataFrame DataFrame::select(const std::vector<std::string> &cols)
 {
-    spark::connect::Plan plan;
+    Plan plan;
 
     // ---------------------------------------------------------------------
     // Use the pointer to the root to ensure we are copying the content
@@ -470,9 +470,47 @@ DataFrame DataFrame::select(const std::vector<std::string> &cols)
     return DataFrame(stub_, plan, session_id_, user_id_);
 }
 
+DataFrame DataFrame::select(const std::vector<spark::sql::types::Column> &cols)
+{
+    Plan plan;
+    auto *project = plan.mutable_root()->mutable_project();
+
+    // -------------------------------------------------------------------
+    // Set the input to the current plan's root
+    // We need this in order to support chaining transformations
+    // -------------------------------------------------------------------
+    if (this->plan_.has_root())
+    {
+        project->mutable_input()->CopyFrom(this->plan_.root());
+    }
+
+    for (const auto &column : cols)
+    {
+        // ---------------------------------------------------
+        // Add a new expression to the projection list
+        // ---------------------------------------------------
+        auto *expr = project->add_expressions();
+
+        if (column.expr)
+        {
+            expr->CopyFrom(*column.expr);
+        }
+    }
+
+    return DataFrame(stub_, plan, session_id_, user_id_);
+}
+
+DataFrame DataFrame::select(std::initializer_list<std::string> cols)
+{
+    // ---------------------------------------------------------------
+    // Convert initializer_list to vector and call the string version
+    // ---------------------------------------------------------------
+    return select(std::vector<std::string>(cols));
+}
+
 DataFrame DataFrame::limit(int n)
 {
-    spark::connect::Plan plan;
+    Plan plan;
     auto *limit_rel = plan.mutable_root()->mutable_limit();
     *limit_rel->mutable_input() = this->plan_.root();
     limit_rel->set_limit(n);
@@ -563,7 +601,7 @@ int64_t DataFrame::count()
     // -----------------------------------------------------
     // Initialize the Plan and the Aggregate Relation
     // -----------------------------------------------------
-    spark::connect::Plan plan;
+    Plan plan;
     auto *aggregate = plan.mutable_root()->mutable_aggregate();
 
     // -------------------------------------------------------------------------------
@@ -655,7 +693,7 @@ int64_t DataFrame::count()
 
 DataFrame DataFrame::filter(const std::string &condition)
 {
-    spark::connect::Plan plan;
+    Plan plan;
 
     // ------------------------------------------------------
     // Access the Filter relation in the new plan root
@@ -733,7 +771,7 @@ DataFrame DataFrame::dropDuplicates()
 
 DataFrame DataFrame::dropDuplicates(const std::vector<std::string> &subset)
 {
-    spark::connect::Plan plan;
+    Plan plan;
 
     auto *relation = plan.mutable_root()->mutable_deduplicate();
 
@@ -838,7 +876,7 @@ std::vector<spark::sql::types::Row> DataFrame::collect()
 
 DataFrame DataFrame::distinct()
 {
-    spark::connect::Plan plan;
+    Plan plan;
 
     auto *deduplicate = plan.mutable_root()->mutable_deduplicate();
 
@@ -851,7 +889,7 @@ DataFrame DataFrame::distinct()
 
 DataFrame DataFrame::describe(const std::vector<std::string> &cols)
 {
-    spark::connect::Plan plan;
+    Plan plan;
 
     auto *relation = plan.mutable_root()->mutable_describe();
     relation->mutable_input()->CopyFrom(this->plan_.root());
@@ -866,7 +904,7 @@ DataFrame DataFrame::describe(const std::vector<std::string> &cols)
 
 DataFrame DataFrame::summary(const std::vector<std::string> &statistics)
 {
-    spark::connect::Plan plan;
+    Plan plan;
 
     auto *summary_rel = plan.mutable_root()->mutable_summary();
 
@@ -887,7 +925,7 @@ DataFrame DataFrame::summary()
 
 DataFrame DataFrame::join(const DataFrame &other) const
 {
-    spark::connect::Plan plan;
+    Plan plan;
     auto *join = plan.mutable_root()->mutable_join();
 
     if (this->plan_.has_root())
@@ -919,7 +957,7 @@ DataFrame DataFrame::join(const DataFrame &other) const
 
 DataFrame DataFrame::join(const DataFrame &other, const std::string &on, const std::string &how)
 {
-    spark::connect::Plan plan;
+    Plan plan;
 
     auto *join = plan.mutable_root()->mutable_join();
 
@@ -982,7 +1020,7 @@ DataFrame DataFrame::join(const DataFrame &other, const std::string &on, const s
 
 DataFrame DataFrame::join(const DataFrame &other, const std::vector<std::string> &on, const std::string &how)
 {
-    spark::connect::Plan plan;
+    Plan plan;
 
     auto *join = plan.mutable_root()->mutable_join();
 
@@ -1049,7 +1087,7 @@ DataFrame DataFrame::join_on_expression(const DataFrame &other,
         throw std::invalid_argument("Join condition cannot be empty.");
     }
 
-    spark::connect::Plan plan;
+    Plan plan;
     auto *join = plan.mutable_root()->mutable_join();
 
     // -----------------------------------------

--- a/src/dataframe.h
+++ b/src/dataframe.h
@@ -87,8 +87,19 @@ public:
     /**
      * @brief Projects a set of expressions and returns a new DataFrame.
      * @param cols A vector of column names.
+     * @example auto df_subset = df.select({"b", "a"});
      */
     DataFrame select(const std::vector<std::string> &cols);
+
+    /**
+     * @brief Projects a set of `Column` expressions and returns a new DataFrame.
+     * @param cols A vector of `Column` objects (supporting aliases, math, etc.).
+     * @example auto filtered_df = df.filter(col("name") == lit("Alice"))
+     *                     .select({col("name"), _col.alias("age_plus_one")});
+     */
+    DataFrame select(const std::vector<spark::sql::types::Column> &cols);
+
+    DataFrame select(std::initializer_list<std::string> cols);
 
     /**
      * @brief Filters rows using the given SQL condition string.

--- a/tests/expressions.cpp
+++ b/tests/expressions.cpp
@@ -46,24 +46,21 @@ TEST_F(SparkIntegrationTest, ColumnExpressions)
             AS people(name, age)
         )");
 
-        // -----------------------------------------
-        // Define the expression: age + 1
-        // -----------------------------------------
-        auto _col = col("age") + lit(1);
+    // -----------------------------------------
+    // Define the expression: age + 1
+    // -----------------------------------------
+    auto _col = col("age") + lit(1);
 
     // -----------------------------------------------------------------------
     // Use .select() to include the new expression in the output
     // We alias it to "age_plus_one" so we can find it in the resulting Row
     // -----------------------------------------------------------------------
-    
-    // ------------------------------------------------------------------------
-    // Temporarily commenting this out until we figure out overloading for DataFrame::select()
-    //
-    // auto filtered_df = df.filter(col("name") == lit("Alice"))
-    //                        .select({col("name"), _col.alias("age_plus_one")});
-    // ------------------------------------------------------------------------
 
-    auto filtered_df = df.filter(col("name") == lit("Alice"));
+    auto filtered_df = df.filter(col("name") == lit("Alice"))
+                           .select({col("name"), _col.alias("age_plus_one")});
+
+    filtered_df.show();
+
     auto rows = filtered_df.collect();
 
     ASSERT_EQ(rows.size(), 1);
@@ -72,6 +69,6 @@ TEST_F(SparkIntegrationTest, ColumnExpressions)
     // ---------------------------------------------------------------
     // Evaluate the _col expression result (23 + 1 = 24)
     // ---------------------------------------------------------------
-    // int64_t expected_age = 23 + 1;
-    // EXPECT_EQ(rows[0].get_long("age_plus_one"), expected_age);
+    int64_t expected_age = 23 + 1;
+    EXPECT_EQ(rows[0].get_long("age_plus_one"), expected_age);
 }


### PR DESCRIPTION
### Description

This PR enhances the `DataFrame::select` API to support complex Column expressions. Previously, `select()` only accepted a vector of strings, limiting users to simply reordering or subsetting existing columns.

With this update, users can now perform arithmetic, aliases, and other column transformations directly within the selection list.

### Key Changes

* Overloaded `DataFrame::select`: Added support for `std::vector<Column>` to allow projecting complex expressions.
* **Resolved Overload Ambiguity**: Added an `std::initializer_list<std::string>` overload to prevent compiler errors when passing braced string literals (e.g., `df.select({"a", "b"})`).
* **Plan Generation**: Updated the logic to correctly populate the `Project` relation in the Spark Connect protobuf using the underlying expression tree of the `Column` objects.

### Example Usage

```cpp
// Now possible:
auto df2 = df.select({
    col("name"), 
    (col("age") + lit(1)).alias("age_next_year")
});

```

### Integration Testing

Updated existing test case `ColumnExpressions` in `SparkIntegrationTest` to verify:

1. Successful projection of calculated columns.
2. Correct handling of column aliasing.
3. Integration with existing filters.
4. Maintenance of schema integrity in the resulting DataFrame.
