### PR TITLE
[SPARK-CONNECT][CPP] Refactor Column DSL to functions namespace and implement String/Conditional API

### DIFF
--- a/src/dataframe.cpp
+++ b/src/dataframe.cpp
@@ -19,6 +19,7 @@
 #include <google/protobuf/wrappers.pb.h>
 
 #include "dataframe.h"
+#include "functions.h"
 #include "types.h"
 #include "writer.h"
 #include "group.h"
@@ -471,7 +472,7 @@ DataFrame DataFrame::select(const std::vector<std::string> &cols) const
     return DataFrame(stub_, plan, session_id_, user_id_);
 }
 
-DataFrame DataFrame::select(const std::vector<spark::sql::types::Column> &cols) const
+DataFrame DataFrame::select(const std::vector<spark::sql::functions::Column> &cols) const
 {
     Plan plan;
     auto *project = plan.mutable_root()->mutable_project();
@@ -646,7 +647,7 @@ DataFrame DataFrame::filter(const std::string &condition) const
     return DataFrame(stub_, plan, session_id_, user_id_);
 }
 
-DataFrame DataFrame::filter(const spark::sql::types::Column &condition) const
+DataFrame DataFrame::filter(const spark::sql::functions::Column &condition) const
 {
     Plan plan;
     auto *filter_rel = plan.mutable_root()->mutable_filter();
@@ -1076,11 +1077,11 @@ GroupedData DataFrame::groupBy()
  */
 GroupedData DataFrame::groupBy(const std::vector<std::string> &cols)
 {
-    std::vector<spark::sql::types::Column> col_exprs;
+    std::vector<spark::sql::functions::Column> col_exprs;
     col_exprs.reserve(cols.size());
     for (const auto &name : cols)
     {
-        col_exprs.push_back(spark::sql::types::col(name));
+        col_exprs.push_back(spark::sql::functions::col(name));
     }
     return GroupedData(*this, std::move(col_exprs));
 }
@@ -1088,7 +1089,7 @@ GroupedData DataFrame::groupBy(const std::vector<std::string> &cols)
 /**
  * @brief Grouping by Column expressions. This allows for math/aliases in grouping.
  */
-GroupedData DataFrame::groupBy(const std::vector<spark::sql::types::Column> &cols)
+GroupedData DataFrame::groupBy(const std::vector<spark::sql::functions::Column> &cols)
 {
     return GroupedData(*this, cols);
 }
@@ -1099,4 +1100,21 @@ GroupedData DataFrame::groupBy(const std::vector<spark::sql::types::Column> &col
 GroupedData DataFrame::groupBy(std::initializer_list<std::string> cols)
 {
     return groupBy(std::vector<std::string>(cols));
+}
+
+DataFrame DataFrame::withColumn(const std::string &colName, const spark::sql::functions::Column &col) const
+{
+    spark::connect::Relation rel;
+    auto *with_cols = rel.mutable_with_columns();
+
+    *with_cols->mutable_input() = this->plan_.root();
+
+    auto *alias = with_cols->add_aliases();
+    alias->add_name(colName);
+    *alias->mutable_expr() = *col.expr;
+
+    spark::connect::Plan new_plan;
+    *new_plan.mutable_root() = rel;
+
+    return DataFrame(stub_, new_plan, session_id_, user_id_);
 }

--- a/src/dataframe.h
+++ b/src/dataframe.h
@@ -7,7 +7,10 @@
 #include <spark/connect/base.grpc.pb.h>
 #include <spark/connect/relations.pb.h>
 
-#include <types.h>
+#include "functions.h"
+#include "types.h"
+
+using namespace spark::sql::types;
 
 class DataFrameWriter;
 class GroupedData;
@@ -64,7 +67,7 @@ public:
      * @brief Returns the schema of this DataFrame as a StructType.
      * @return A StructType object containing the full schema metadata.
      */
-    spark::sql::types::StructType schema() const;
+    StructType schema() const;
 
     /**
      * @brief Prints out the schema in the tree format.
@@ -98,7 +101,7 @@ public:
      * @example auto filtered_df = df.filter(col("name") == lit("Alice"))
      *                     .select({col("name"), _col.alias("age_plus_one")});
      */
-    DataFrame select(const std::vector<spark::sql::types::Column> &cols) const;
+    DataFrame select(const std::vector<spark::sql::functions::Column> &cols) const;
 
     DataFrame select(std::initializer_list<std::string> cols) const;
 
@@ -112,7 +115,7 @@ public:
      * @brief Filters rows using a Column expression.
      * @param condition Column expression (e.g., col("age") > lit(21))
      */
-    DataFrame filter(const spark::sql::types::Column &condition) const;
+    DataFrame filter(const spark::sql::functions::Column &condition) const;
 
     /**
      * @brief Alias for filter().
@@ -122,22 +125,22 @@ public:
     /**
      * @brief Returns the first n rows.
      */
-    std::vector<spark::sql::types::Row> take(int n);
+    std::vector<Row> take(int n);
 
     /**
      * @brief Returns the first row.
      */
-    std::optional<spark::sql::types::Row> head();
+    std::optional<Row> head();
 
     /**
      * @brief Returns the first n rows.
      */
-    std::vector<spark::sql::types::Row> head(int n);
+    std::vector<Row> head(int n);
 
     /**
      * @brief Returns the first row.
      */
-    std::optional<spark::sql::types::Row> first();
+    std::optional<Row> first();
 
     /**
      * @brief Returns a new DataFrame by taking the first n rows.
@@ -200,7 +203,7 @@ public:
      * // ------------------------------------------
      * @returns A list of rows.
      */
-    std::vector<spark::sql::types::Row> collect();
+    std::vector<Row> collect();
 
     /**
      * @brief Returns a new `DataFrame` containing the distinct rows.
@@ -333,7 +336,7 @@ public:
      * @brief Groups the DataFrame using the specified columns.
      */
     GroupedData groupBy(const std::vector<std::string> &cols);
-    GroupedData groupBy(const std::vector<spark::sql::types::Column> &cols);
+    GroupedData groupBy(const std::vector<spark::sql::functions::Column> &cols);
     GroupedData groupBy(std::initializer_list<std::string> cols);
     GroupedData groupBy();
 
@@ -353,6 +356,16 @@ public:
         // --------------------------------------------------------------------
         return func(*this, std::forward<Args>(args)...);
     }
+
+    /**
+     * @brief Returns a new `DataFrame` by adding a column or replacing the existing column that has the same name.
+     *
+     * The column expression must be an expression over this `DataFrame`, attempting to add a column from some other DataFrame will raise an error.
+     *
+     * @param colName The name of the new column.
+     * @param col The column expression for the new column.
+     */
+    DataFrame withColumn(const std::string &colName, const spark::sql::functions::Column &col) const;
 
 private:
     friend class GroupedData;

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1,0 +1,128 @@
+#include "functions.h"
+#include "types.h"
+
+#include <spark/connect/expressions.pb.h>
+
+namespace spark::sql::functions
+{
+
+    using namespace spark::sql::types;
+
+    Column::Column(std::string name) : expr(std::make_shared<spark::connect::Expression>())
+    {
+        expr->mutable_unresolved_attribute()->set_unparsed_identifier(name);
+    }
+
+    Column::Column(spark::connect::Expression e) : expr(std::make_shared<spark::connect::Expression>(std::move(e))) {}
+
+    /**
+     * @brief Helper to build Spark's UnresolvedFunction calls
+     */
+    static Column build_binary_op(const std::string &op, const Column &l, const Column &r)
+    {
+        spark::connect::Expression e;
+        auto *func = e.mutable_unresolved_function();
+        func->set_function_name(op);
+        *func->add_arguments() = *l.expr;
+        *func->add_arguments() = *r.expr;
+        return Column(std::move(e));
+    }
+
+    Column Column::operator+(const Column &other) const { return build_binary_op("+", *this, other); }
+    Column Column::operator-(const Column &other) const { return build_binary_op("-", *this, other); }
+    Column Column::operator*(const Column &other) const { return build_binary_op("*", *this, other); }
+    Column Column::operator/(const Column &other) const { return build_binary_op("/", *this, other); }
+    Column Column::operator==(const Column &other) const { return build_binary_op("==", *this, other); }
+    Column Column::operator>(const Column &other) const { return build_binary_op(">", *this, other); }
+    Column Column::operator<(const Column &other) const { return build_binary_op("<", *this, other); }
+
+    Column Column::alias(const std::string &name) const
+    {
+        spark::connect::Expression e;
+        auto *a = e.mutable_alias();
+        *a->mutable_expr() = *this->expr;
+        a->add_name(name);
+        return Column(std::move(e));
+    }
+
+    Column Column::otherwise(const Column &value) const
+    {
+        spark::connect::Expression e;
+        auto *func = e.mutable_unresolved_function();
+
+        func->set_function_name("when");
+
+        // -------------------------------------------------------------------
+        // Copy existing arguments from the 'when' call if they exist
+        // -------------------------------------------------------------------
+        if (this->expr->has_unresolved_function())
+        {
+            for (const auto &arg : this->expr->unresolved_function().arguments())
+            {
+                *func->add_arguments() = arg;
+            }
+        }
+
+        *func->add_arguments() = *value.expr;
+        return Column(std::move(e));
+    }
+
+    Column lower(const Column &e)
+    {
+        spark::connect::Expression expr;
+        auto *func = expr.mutable_unresolved_function();
+        func->set_function_name("lower");
+        *func->add_arguments() = *e.expr;
+        return Column(std::move(expr));
+    }
+
+    Column col(const std::string &name) { return Column(name); }
+
+    Column lit(int32_t value)
+    {
+        spark::connect::Expression e;
+        e.mutable_literal()->set_integer(value);
+        return Column(std::move(e));
+    }
+
+    Column lit(double value)
+    {
+        spark::connect::Expression e;
+        e.mutable_literal()->set_double_(value);
+        return Column(std::move(e));
+    }
+
+    Column lit(const std::string &value)
+    {
+        spark::connect::Expression e;
+        e.mutable_literal()->set_string(value);
+        return Column(std::move(e));
+    }
+
+    Column concat_ws(const std::string &sep, const std::vector<Column> &cols)
+    {
+        spark::connect::Expression e;
+        auto *func = e.mutable_unresolved_function();
+        func->set_function_name("concat_ws");
+
+        // -------------------------------------------------
+        // Assign the Protobuf Expression gotten via .expr
+        // -------------------------------------------------
+        *func->add_arguments() = *lit(sep).expr;
+        for (const auto &c : cols)
+        {
+            *func->add_arguments() = *c.expr;
+        }
+        return Column(std::move(e));
+    }
+
+    Column when(const Column &condition, const Column &value)
+    {
+        spark::connect::Expression e;
+        auto *func = e.mutable_unresolved_function();
+        func->set_function_name("when");
+        *func->add_arguments() = *condition.expr;
+        *func->add_arguments() = *value.expr;
+        return Column(std::move(e));
+    }
+}

--- a/src/functions.h
+++ b/src/functions.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+#include "types.h"
+
+namespace spark::connect
+{
+    class Expression;
+}
+
+namespace spark::sql::functions
+{
+
+    /**
+     * @brief The Column class represents a Spark Expression (DSL).
+     * We keep it here because it's the primary tool for 'functions'.
+     */
+    struct Column
+    {
+        std::shared_ptr<spark::connect::Expression> expr;
+
+        explicit Column(std::string name);
+        explicit Column(spark::connect::Expression e);
+
+        // ------------------
+        // DSL Operators
+        // ------------------
+        Column operator+(const Column &other) const;
+        Column operator-(const Column &other) const;
+        Column operator*(const Column &other) const;
+        Column operator/(const Column &other) const;
+        Column operator==(const Column &other) const;
+        Column operator>(const Column &other) const;
+        Column operator<(const Column &other) const;
+
+        Column alias(const std::string &name) const;
+        Column otherwise(const Column &value) const;
+    };
+
+    /**
+     * @brief Returns a `Column` based on the given column name.
+     */
+    Column col(const std::string &name);
+
+    /**
+     * @brief Creates a `Column` of literal value.
+     */
+    Column lit(int32_t value);
+    Column lit(double value);
+    Column lit(const std::string &value);
+
+    /**
+     * @brief Converts a string expression to lower case.
+     */
+    Column lower(const Column &e);
+
+    /**
+     * @brief Concatenates multiple input string columns together into a single string column, using the given separator.
+     */
+    Column concat_ws(const std::string &sep, const std::vector<Column> &cols);
+
+    /**
+     * @brief Evaluates a list of conditions and returns one of multiple possible result expressions.
+     */
+    Column when(const Column &condition, const Column &value);
+
+}

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -1,6 +1,6 @@
 #include "group.h"
 
-GroupedData::GroupedData(DataFrame &df, std::vector<spark::sql::types::Column> grouping_cols)
+GroupedData::GroupedData(DataFrame &df, std::vector<spark::sql::functions::Column> grouping_cols)
     : df_(df), grouping_cols_(grouping_cols) {}
 
 /**

--- a/src/group.h
+++ b/src/group.h
@@ -3,19 +3,22 @@
 #include <vector>
 #include <string>
 #include <memory>
+
 #include "dataframe.h"
+#include "functions.h"
 #include "types.h"
 
-class GroupedData {
+class GroupedData
+{
 public:
-    GroupedData(DataFrame& df, std::vector<spark::sql::types::Column> grouping_cols);
+    GroupedData(DataFrame &df, std::vector<spark::sql::functions::Column> grouping_cols);
 
     DataFrame count();
-    DataFrame sum(const std::vector<std::string>& cols);
-    DataFrame avg(const std::vector<std::string>& cols);
+    DataFrame sum(const std::vector<std::string> &cols);
+    DataFrame avg(const std::vector<std::string> &cols);
     // ...
 
 private:
-    DataFrame& df_;
-    std::vector<spark::sql::types::Column> grouping_cols_;
+    DataFrame &df_;
+    std::vector<spark::sql::functions::Column> grouping_cols_;
 };

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,10 +1,12 @@
 #include <sstream>
 #include <iomanip>
 #include <algorithm>
+
 #include "types.h"
 
 #include <spark/connect/expressions.pb.h>
 #include <spark/connect/types.pb.h>
+
 #include <arrow/array.h>
 
 namespace spark::sql::types
@@ -413,58 +415,5 @@ namespace spark::sql::types
         }
         os << ")";
         return os;
-    }
-
-    Column::Column(std::string name) : expr(std::make_shared<spark::connect::Expression>())
-    {
-        expr->mutable_unresolved_attribute()->set_unparsed_identifier(name);
-    }
-
-    Column::Column(spark::connect::Expression e) : expr(std::make_shared<spark::connect::Expression>(std::move(e))) {}
-
-    /**
-     * @brief Helper to build Spark's UnresolvedFunction calls
-     */
-    static Column build_binary_op(const std::string &op, const Column &l, const Column &r)
-    {
-        spark::connect::Expression e;
-        auto *func = e.mutable_unresolved_function();
-        func->set_function_name(op);
-        *func->add_arguments() = *l.expr;
-        *func->add_arguments() = *r.expr;
-        return Column(std::move(e));
-    }
-
-    Column Column::operator+(const Column &other) const { return build_binary_op("+", *this, other); }
-    Column Column::operator-(const Column &other) const { return build_binary_op("-", *this, other); }
-    Column Column::operator*(const Column &other) const { return build_binary_op("*", *this, other); }
-    Column Column::operator/(const Column &other) const { return build_binary_op("/", *this, other); }
-    Column Column::operator==(const Column &other) const { return build_binary_op("==", *this, other); }
-    Column Column::operator>(const Column &other) const { return build_binary_op(">", *this, other); }
-    Column Column::operator<(const Column &other) const { return build_binary_op("<", *this, other); }
-
-    Column Column::alias(const std::string &name) const
-    {
-        spark::connect::Expression e;
-        auto *a = e.mutable_alias();
-        *a->mutable_expr() = *this->expr;
-        a->add_name(name);
-        return Column(std::move(e));
-    }
-
-    Column col(const std::string &name) { return Column(name); }
-
-    Column lit(int32_t value)
-    {
-        spark::connect::Expression e;
-        e.mutable_literal()->set_integer(value);
-        return Column(std::move(e));
-    }
-
-    Column lit(const std::string &value)
-    {
-        spark::connect::Expression e;
-        e.mutable_literal()->set_string(value);
-        return Column(std::move(e));
     }
 }

--- a/src/types.h
+++ b/src/types.h
@@ -295,34 +295,8 @@ namespace spark::sql::types
     /**
      * @brief Converts an Arrow Array value at a specific row into a Spark `ColumnValue`.
      * This acts as a bridge between the Arrow transport layer and the respective C++ Row model.
-     * 
+     *
      * See: `Row` implementation.
      */
     ColumnValue arrayValueToVariant(const std::shared_ptr<arrow::Array> &array, int64_t row);
-
-    struct Column
-    {
-        std::shared_ptr<spark::connect::Expression> expr;
-
-        explicit Column(std::string name);
-        explicit Column(spark::connect::Expression e);
-
-        // ---------------------------
-        // DSL Operators
-        // ---------------------------
-        Column operator+(const Column &other) const;
-        Column operator-(const Column &other) const;
-        Column operator*(const Column &other) const;
-        Column operator/(const Column &other) const;
-        Column operator==(const Column &other) const;
-        Column operator>(const Column &other) const;
-        Column operator<(const Column &other) const;
-
-        Column alias(const std::string &name) const;
-    };
-
-    Column col(const std::string &name);
-    Column lit(int32_t value);
-    Column lit(double value);
-    Column lit(const std::string &value);
 }

--- a/tests/aggregations.cpp
+++ b/tests/aggregations.cpp
@@ -1,12 +1,15 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <gmock/gmock-matchers.h>
+
 #include "session.h"
 #include "config.h"
 #include "dataframe.h"
 #include "group.h"
+#include "functions.h"
 #include "types.h"
 
+using namespace spark::sql::functions;
 using namespace spark::sql::types;
 using ::testing::ElementsAre;
 

--- a/tests/dataframe.cpp
+++ b/tests/dataframe.cpp
@@ -1,12 +1,16 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+
 #include <iostream>
 #include <sstream>
+
 #include "session.h"
 #include "config.h"
 #include "dataframe.h"
+#include "functions.h"
 #include "types.h"
 
+using namespace spark::sql::functions;
 using namespace spark::sql::types;
 using ::testing::ElementsAre;
 
@@ -715,4 +719,54 @@ TEST_F(SparkIntegrationTest, DataFrameTransform)
     EXPECT_EQ(rows[3].get_long("(id * 10)"), 90);
 
     EXPECT_EQ(rows.size(), 4);
+}
+
+TEST_F(SparkIntegrationTest, ChainedDataFrameTransforms)
+{
+    auto raw_df = spark->sql(
+        R"(
+            SELECT * FROM VALUES 
+                ('John', 'Doe', 25, 'JOHN.DOE@GMAIL.COM'), 
+                ('Jane', 'Smith', 15, 'jane_smith@yahoo.com'), 
+                ('Alice', 'Brown', 30, 'ALICE.B@PROV.EDU'), 
+                ('Bob', 'Wilson', 17, 'bob.wilson@startup.io'), 
+                ('Charlie', 'Davis', 12, 'CHarlie@D-NET.COM'), 
+                ('Diana', 'Prince', 28, 'DIANA.PRINCE@AMAZON.COM'), 
+                ('Ethan', 'Hunt', 45, 'ETHAN_HUNT@IMF.GOV'), 
+                ('Fiona', 'Gallagher', 16, 'fiona.g@southside.net'), 
+                ('Grant', 'Martin', 72, 'GRRM@CMPNY.COM'), 
+                ('Hannah', 'Abbott', 18, 'h.abbott@hogwarts.ac.uk') 
+            AS people(first, last, age, email)
+        )");
+
+    EXPECT_NO_THROW(raw_df.show());
+
+    auto add_full_name = [](const DataFrame &df)
+    {
+        return df.withColumn("full_name", spark::sql::functions::concat_ws(" ", {col("first"), col("last")}));
+    };
+
+    auto clean_email = [](const DataFrame &df)
+    {
+        return df.withColumn("email", lower(col("email")));
+    };
+
+    auto add_status = [](const DataFrame &df)
+    {
+        return df.withColumn("status",
+                             when(col("age") > lit(18),
+                                  lit("adult"))
+                                 .otherwise(lit("minor")));
+    };
+
+    auto df = raw_df
+                  .transform(add_full_name)
+                  .transform(clean_email)
+                  .transform(add_status);
+
+    EXPECT_NO_THROW(df.show());
+
+    auto cols = df.columns();
+
+    EXPECT_GT(cols.size(), raw_df.columns().size());
 }

--- a/tests/expressions.cpp
+++ b/tests/expressions.cpp
@@ -4,8 +4,10 @@
 #include "session.h"
 #include "dataframe.h"
 #include "config.h"
+#include "functions.h"
 #include "types.h"
 
+using namespace spark::sql::functions;
 using namespace spark::sql::types;
 using ::testing::ElementsAre;
 


### PR DESCRIPTION
Migrating the Expression DSL from the data layer (`types.h`) to a dedicated logic layer (`functions.h`).

Key implementation details include:

* **DSL Migration:** Moved `struct Column` definition and operator implementations (+, -, *, ==, etc.) to the `spark::sql::functions` namespace to decouple plan-building logic from Row/DataType storage models.
* **Factory Functions:** Implemented standalone `col()` and `lit()` (supporting `int32_t`, `double`, and `std::string`) as the primary entry points for expression building.
* **String & Conditional API:** Added `functions::lower` for string normalization and `functions::when/otherwise` for branching logic within the logical plan.
* **Variadic Support:** Implemented `functions::concat_ws` using the `UnresolvedFunction` Protobuf message to handle multiple column arguments with a separator.

Testing performed:

* **ChainedDataFrameTransforms:** Verified a 10-row dataset transformation pipeline using `transform()`, `withColumn()`, and `lower()`.
* **Linker Validation:** Confirmed that moving DSL symbols to `functions.cpp` resolved `undefined reference` errors in `test_dataframe` and `test_dataframe_reader`.

Why is this change necessary?
Previously, the DSL was mixed into the data types, creating potential circular dependencies and a non-standard API. Moving to a `functions` namespace allows for a fluent, readable pipeline syntax that mirrors PySpark and Scala.

Does this introduce a user-facing change?
Yes. Users can now build readable, chained pipelines:

```cpp
auto clean_email = [](const DataFrame& df) {
    return df.withColumn("email", functions::lower(col("email")))
             .withColumn("status", when(col("age") > lit(18), lit("adult")).otherwise(lit("minor")));
};
auto result = df.transform(clean_email);

```