### PR TITLE
[SPARK-CONNECT][CPP] (chore) Replace VCPKG toolchain with PkgConfig module

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,8 +13,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      VCPKG_BINARY_CACHE: ${{ github.workspace }}/.devops/vcpkg_toolchain/vcpkg-package
 
     steps:
       - uses: actions/checkout@v4
@@ -26,14 +24,6 @@ jobs:
 
       - name: Verify CMake version
         run: cmake --version
-
-      - name: Cache vcpkg binaries
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.VCPKG_BINARY_CACHE }}
-          key: ${{ runner.os }}-vcpkg-{{ hashFiles('**/vcpkg.json') }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-
 
       - name: Install Java
         uses: actions/setup-java@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,28 +161,18 @@ Does this introduce a user-facing change?
 - Aim for >80% code coverage on new code
 - Tests should be deterministic (no flaky tests)
 
-
-This project uses **vcpkg** in a *Pre-built SDK* model to ensure consistent builds and minimize compilation times for contributors. Please follow the steps below when setting up or modifying project dependencies.
-
-
+This project relies on **pkg-config** for dependency management. Contributors are expected to install the required libraries on their local systems and ensure that the corresponding `.pc` files are available for discovery.
+ 
 ## IMPORTANT
-**Note:** All dependency management steps and scripts are located within the **`.devops`** folder. Ensure your terminal is correctly navigated to this directory.
-
+**Note:** You can use the provided script in **`.devops/install-deps.sh`** to install the required dependencies on supported Linux distributions.
 
 ## Initial Environment Setup
 
 Before configuring the project for the first time, you must ensure your local environment has the required build tools.
 
-1. Run the setup script:
-   ```bash
-   chmod u+x ./vcpkg-setup.sh
-   ./vcpkg-setup.sh
-    ```
-
-2.  This will verify or install:
-    *   **CMake**
-    *   **Ninja-build**
-    *   **vcpkg**
+*   **CMake** - version 3.16 or later is recommended.
+*   **Ninja-build** or **Make**
+*   **PkgConfig**
 
 ## Development Environment Setup
 
@@ -210,88 +200,20 @@ cmake --build --preset local
 
 ## Managing Dependencies
 
-### 1. Adding a New Dependency
+### 1. Installing Libraries
+Contributors are responsible for installing the development versions of required libraries. These must provide `.pc` metadata files for `pkg-config` to provide the necessary compilation and linking flags.
 
-All libraries are tracked in the `vcpkg.json` manifest file. To add a new library:
-
-*   Open `vcpkg.json`
-*   Add the required package to the `dependencies` list
-*   **Note:** Any changes to this file require a new binary export (see below) to ensure the SDK stays up to date
-
-### 2. Exporting the SDK
-
-If you update `vcpkg.json`, you must generate a new binary archive for the team:
-
-*  Run the export script:
-    ```bash
-    ./vcpkg-package-export.sh
-    ```
-
-*  This script builds the dependencies and creates a zip archive inside the `vcpkg_export` folder.
-
-*  The resulting file will be named `vcpkg-package.zip`.
-
-### 3. Local Development Workflow
-
-When you need a new library for a feature you are currently developing, you do not need to publish a release immediately.
-
-*   Update vcpkg.json with the new library.
-
-*   Run the export script:
-    ```bash
-    ./vcpkg-package-export.sh
-    ```
-
-*   **Automatic Local Extraction**: The export script includes a final step that extracts the newly built binaries directly into your local environment, inside the `vcpkg_toolchain` folder.
-
-This allows you to continue development and consume the new library locally without waiting for an official GitHub Release.
-
-### 3. Exporting the SDK
-
-Once your local development is complete and you are ready to share the changes:
-
-*  Ensure `vcpkg-package-export.sh` has been run to generate the final `vcpkg-package.zip`.
-
-*  This zip contains the pre-built binaries including your recent additions.
-
-
-## Distribution and Consumption
-
-### Distributing via GitHub
-
-To share updated dependencies with the team, we use an automated GitHub Actions pipeline:
-
-*   **Update the Version**: In your Pull Request, update the `SDK_VERSION` variable in the GitHub Action YAML file to your desired new version tag (e.g., v2.0.1).
-
-*   **Merge to `main/dev/branch-v.x.x`**: Once your changes to `vcpkg.json` are merged into the protected branches, the pipeline triggers automatically.
-
-*   **Automated Release**: The pipeline runs the export script and automatically uploads the `vcpkg-package.zip` to the GitHub Releases page under the specified Version Tag
-
-### Updating the Project to Use the New SDK
-
-After the pipeline completes the release, you must update the project configuration to consume it:
-
-*   Open .devops/vcpkg-package.cmake.
-
-*   Update the PACKAGE_VERSION variable to match the new GitHub Release tag.
-
-    ```cmake
-    # Update in .devops/vcpkg-package.cmake
-    set(PACKAGE_VERSION "vX.Y.Z")
-    ```
-
-Once this change is committed, `vcpkg-package.cmake` will automatically handle downloading and extracting the updated binaries for all other team members during their next CMake configuration.
-
+### 2. Adding a New Dependency
+If you introduce a new dependency to the project:
+*   Verify that the library provides a `pkg-config` (`.pc`) file.
+*   Update the `CMakeLists.txt` using the `pkg_check_modules` command.
+*   Update the documentation (e.g., `README.md` or this guide) to list the new requirement.
 
 ## File Summary
 
 | File                      | Description                                           |
 | ------------------------- | ----------------------------------------------------- |
-| `vcpkg-setup.sh`          | Installs required build tools (CMake, Ninja, vcpkg)   |
-| `vcpkg.json`              | Manifest file listing current project dependencies    |
-| `vcpkg-package-export.sh` | Builds and zips dependencies into `vcpkg-package.zip` |
-| `vcpkg-package.zip`       | Final artifact containing pre-built binaries          |
-| `vcpkg-package.cmake`     | Downloads the SDK based on `PACKAGE_VERSION`          |
+| `.devops/install-deps.sh` | Shell script to install core dependencies on Linux    |
 
 ## Recognition
 


### PR DESCRIPTION
### Description
Updated the documentation and PR pipeline to incorporate new steps for dependency management using PkgConfig

### Key Implementation Details
- **CONTRIBUTING.md:** Added detailed steps for installing dependencies via PkgConfig
- **build_and_test.yml:** Removed VCPKG binary caching from the PR pipeline to reflect the transition

### Testing
N/A

### Why is this change necessary?
The documentation and PR pipeline must stay synchronized with the recent switch to PkgConfig.

### User-Facing Changes
N/A