### PR TITLE
Revise setup instructions and directory structure

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -31,11 +31,13 @@ The project uses an **out-of-source CMake build**:
 spark-connect-cpp/
 ├── CMakeLists.txt
 ├── src/
+├── docs/
+├── datasets/
 ├── tests/
 ├── build/             # Generated (Not committed)
 ├── docker-compose.yaml
-├── install-deps.sh
-├── .vscode/           # Contains IntelliSense config
+├── scripts            # Contains the scripts to install the core libraries
+├── .vscode/          # Contains IntelliSense config
 └── hooks/
 ```
 
@@ -44,6 +46,7 @@ spark-connect-cpp/
 ## Installing Dependencies
 
 ### System Dependencies (Linux / Ubuntu)
+First navigate to the scripts folder
 Run the provided script to install all core libraries:
 ```bash
 chmod +x install-deps.sh


### PR DESCRIPTION
This pull request updates the project documentation to reflect recent changes in the project structure and dependency installation process. The main focus is on clarifying the location of scripts and new directories in the repository.

Documentation updates:

* Updated the project structure in `docs/SETUP.md` to include the new `docs/` and `datasets/` directories, and replaced `install-deps.sh` with a `scripts` directory for core library installation scripts.
* Clarified in `docs/SETUP.md` that users should first navigate to the `scripts` folder before running the dependency installation script.