### PR TITLE
Add alias method to DataFrame for improved column name resolution

### DIFF
--- a/src/dataframe.cpp
+++ b/src/dataframe.cpp
@@ -1169,3 +1169,20 @@ DataFrame DataFrame::withColumn(const std::string& colName,
 
     return DataFrame(stub_, new_plan, session_id_, user_id_);
 }
+/*
+ *@brief aliasing support for dataframes
+ * */
+DataFrame DataFrame::alias(const std::string& alias_name) const
+{
+    Plan plan;
+    auto* subquery_alias = plan.mutable_root()->mutable_subquery_alias();
+
+    if (this->plan_.has_root())
+    {
+        subquery_alias->mutable_input()->CopyFrom(this->plan_.root());
+    }
+
+    subquery_alias->set_alias(alias_name);
+
+    return DataFrame(stub_, plan, session_id_, user_id_);
+}

--- a/src/dataframe.h
+++ b/src/dataframe.h
@@ -430,6 +430,23 @@ class DataFrame
     DataFrame withColumn(const std::string& colName,
                          const spark::sql::functions::Column& col) const;
 
+    /**
+     * @brief Returns a new DataFrame with an alias set.
+     *
+     * Aliasing is particularly useful for resolving column name ambiguities
+     * when performing self-joins, allowing you to refer to columns using
+     * the alias prefix.
+     *
+     * @param alias_name The string alias to apply to this DataFrame.
+     * @return A new DataFrame containing the aliased logical plan.
+     *
+     * @example
+     * auto df1 = df.alias("a");
+     * auto df2 = df.alias("b");
+     * auto joined = df1.join(df2, col("a.id") == col("b.id"));
+     */
+    DataFrame alias(const std::string& alias_name) const;
+
   private:
     friend class GroupedData;
     friend class graphframes::GraphFrame;


### PR DESCRIPTION
This pull request introduces aliasing support to the `DataFrame` class, making it easier to handle column name ambiguities, especially during self-joins. The main change is the addition of an `alias` method, along with its documentation and implementation.

**Aliasing support for DataFrames:**

* Added an `alias` method to the `DataFrame` class in `dataframe.h`, including detailed documentation and usage example. This method returns a new `DataFrame` with an alias set, which is useful for resolving column ambiguities in operations like self-joins.
* Implemented the `alias` method in `dataframe.cpp`, constructing a new logical plan with a subquery alias node that wraps the current DataFrame's plan and sets the provided alias name.