### PR TITLE
SCCPP-94-Support-DFRTable-DFWSave

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -119,3 +119,8 @@ DataFrame DataFrameReader::orc(const std::vector<std::string>& paths)
 {
     return this->format("orc").load({paths});
 }
+
+DataFrame DataFrameReader::table(const std::string& tableName)
+{
+    spark::connect::Plan plan;
+}

--- a/src/reader.h
+++ b/src/reader.h
@@ -134,6 +134,13 @@ class DataFrameReader
      */
     DataFrame orc(const std::vector<std::string>& paths);
 
+    /**
+    * @brief Retrieves a table by name.
+    * @param tableName Name of the table to retrieve.
+    * @return DataFrame containing the contents of the specified table.
+    */
+    DataFrame table(const std::string& tableName);
+
   private:
     std::shared_ptr<spark::connect::SparkConnectService::Stub> stub_;
     Config config_;

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -101,6 +101,11 @@ void DataFrameWriter::save(const std::string& path)
     }
 }
 
+void DataFrameWriter::saveAsTable(const std::string& table_name)
+{
+    spark::connect::Plan plan;
+}
+
 spark::connect::WriteOperation_SaveMode DataFrameWriter::mapSaveMode(const std::string& mode)
 {
     if (mode == "overwrite")


### PR DESCRIPTION
## [SPARK-CONNECT][CPP](type) SCCPP-94-Support-DFRTable-DFWSave

### Description
WIP
### Key Implementation Details
- **Feature/Component Name:** <Description of change>
- **Internal Logic:** <Describe how you handled protobufs, memory, or gRPC stubs>
- **API Changes:** <List any new public methods added to DataFrame or other classes>

### Testing
<Describe how you verified these changes.>
- [ ] New Integration Test: `SparkIntegrationTest.<TestName>`
- [ ] Manual verification via Spark Connect server logs
- [ ] Memory leak check (Valgrind/ASAN)

### Why is this change necessary?
<Explain the motivation, e.g., "To reach feature parity with the PySpark API regarding...">

### User-Facing Changes
**Does this introduce a user-facing change?** (Yes/No)
*If yes, provide a code snippet of the new functionality:*

```cpp
// Example usage here